### PR TITLE
Run the main CI at 6pm and open a control issue in case it fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ name: CI
     branches:
       - "*"
   workflow_dispatch: {}
+  schedule:
+    - cron: 0 18 * * *
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
@@ -44,3 +46,9 @@ jobs:
 
       - name: Check if build left artifacts
         run: git diff --exit-code
+
+      - name: Notify on failed build
+        uses: jayqi/failed-build-issue-action@v1.2.0
+        if: failure() && github.event.pull_request == null
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/arizona_example_live_counter.erl
+++ b/src/arizona_example_live_counter.erl
@@ -19,7 +19,7 @@
 
 -spec mount(Socket) -> Mounted
     when Socket :: arizona_socket:t(),
-         Mounted :: {ok, arizona_socket:t()}.
+         Mounted :: {error, arizona_socket:t()}.
 mount(Socket) ->
     Count = arizona_socket:get_assign(count, Socket, 0),
     {ok, arizona_socket:put_assign(count, Count, Socket)}.

--- a/src/arizona_example_live_counter.erl
+++ b/src/arizona_example_live_counter.erl
@@ -19,7 +19,7 @@
 
 -spec mount(Socket) -> Mounted
     when Socket :: arizona_socket:t(),
-         Mounted :: {error, arizona_socket:t()}.
+         Mounted :: {ok, arizona_socket:t()}.
 mount(Socket) ->
     Count = arizona_socket:get_assign(count, Socket, 0),
     {ok, arizona_socket:put_assign(count, Count, Socket)}.


### PR DESCRIPTION
# Description

If such an issue is created we get notified in GitHub, at least, and then we can have rules to forward this to our emails, if warranted.

**Edit**: it's the first time I'm using this action, so if CI passes, after we merge I'm gonna provoke an issue in main, then fix it, then revert it, so we see what happens 😄 

Closes #2.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona_example/blob/main/CONTRIBUTING.md)
