### PR TITLE
Fix for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
     runs-on: ubuntu-24.04
 
+    timeout-minutes: 15
+
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -44,6 +46,13 @@ jobs:
       - name: Continuous Integration
         run: |
           rebar3 as test ci
+
+      - name: Test release
+        run: |
+          rebar3 release
+          _build/default/rel/arizona_example/bin/arizona_example daemon
+          curl -f -v http://127.0.0.1:8080
+          _build/default/rel/arizona_example/bin/arizona_example stop
 
       - name: Check if build left artifacts
         run: git diff --exit-code

--- a/rebar.config
+++ b/rebar.config
@@ -53,3 +53,10 @@
         "src/**/*.erl"
     ]}
 ]}.
+
+{relx, [
+    {release, {arizona_example, semver}, [arizona_example]},
+    {dev_mode, true},
+    {extended_start_script, true},
+    {include_erts, false}
+]}.

--- a/src/arizona_example.app.src
+++ b/src/arizona_example.app.src
@@ -6,6 +6,7 @@
         % OTP dependencies
         kernel,
         stdlib,
+        sasl,
         % External dependencies
         arizona
     ]},

--- a/src/arizona_example_live_counter.erl
+++ b/src/arizona_example_live_counter.erl
@@ -20,7 +20,7 @@ mount(Socket) ->
     arizona_socket:put_assign(count, Count, Socket).
 
 -spec render(Macros) -> Tree
-    when Macros :: arizona_live_view:macros(),
+    when Macros :: arizona_template_compiler:macros(),
          Tree :: arizona_tpl_parse:tree().
 render(Macros0) ->
     Title = arizona_live_view:get_macro(title, Macros0, ~"Arizona"),
@@ -65,7 +65,7 @@ handle_event(<<"decr">>, _Payload, Socket) ->
 %% component functions.
 
 -spec counter(Macros) -> Tree
-    when Macros :: arizona_live_view:macros(),
+    when Macros :: arizona_template_compiler:macros(),
          Tree :: arizona_tpl_parse:tree().
 counter(Macros) ->
     arizona_live_view:parse_str(~s"""
@@ -76,7 +76,7 @@ counter(Macros) ->
     """, Macros).
 
 -spec button(Macros) -> Tree
-    when Macros :: arizona_live_view:macros(),
+    when Macros :: arizona_template_compiler:macros(),
          Tree :: arizona_tpl_parse:tree().
 button(Macros) ->
     arizona_live_view:parse_str(~s"""


### PR DESCRIPTION
# Description

You break `arizona`'s interface, there's a good change this project's CI breaks too 😄 

Also, we add a new CI element to test for a release and simple call to `localhost:8080`.

This pull request also depends on https://github.com/arizona-framework/arizona/pull/171 and https://github.com/arizona-framework/arizona/pull/172.

Closes #26.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona_example/blob/main/CONTRIBUTING.md)
