### PR TITLE
Make it compatible with the bundler implementation

### DIFF
--- a/src/arizona_example_layout.erl
+++ b/src/arizona_example_layout.erl
@@ -26,7 +26,7 @@ render(View) ->
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{arizona:get_binding(title, View)}</title>
-        {arizona:render_html_scripts()}
+        <script src="assets/js/arizona/main.js"></script>
         <script src="assets/js/main.js"></script>
     </head>
     <body style="height: 100%; margin: 0;">


### PR DESCRIPTION
# Description

https://github.com/arizona-framework/arizona/pull/307 introduces a bundler and has removed the `arizona:render_html_scripts/0` function.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona_example/blob/main/CONTRIBUTING.md)
