### PR TITLE
Add Arizona reloader configuration

### DIFF
--- a/src/arizona_example_app.erl
+++ b/src/arizona_example_app.erl
@@ -23,7 +23,33 @@ start(_StartType, _StartArgs) ->
                 {live, ~"/", arizona_example_view},
                 % WebSocket endpoint for Live connection
                 {live_websocket, ~"/live"}
-            ]
+            ],
+            reloader => #{
+                enabled => true,
+                rules => [
+                    #{
+                        directories => ["src"],
+                        patterns => [".*\\.erl$"],
+                        callback => fun(Files) ->
+                            os:cmd("rebar3 compile"),
+                            lists:foreach(fun(File) ->
+                                BaseName = filename:basename(File, ".erl"),
+                                Module = list_to_existing_atom(BaseName),
+                                % code:purge/1 removes old version from memory
+                                % Required before loading new version to avoid conflicts
+                                code:purge(Module),
+                                % code:load_file/1 loads the newly compiled .beam file
+                                % This makes the updated code active in the running system
+                                code:load_file(Module)
+                            end, Files)
+                        end
+                    },
+                    #{
+                        directories => ["priv/static/assets"],
+                        patterns => ["favicon\\.ico", ".*\\.js$"]
+                    }
+                ]
+            }
         },
         {ok, _ServerPid} ?= arizona_server:start(ServerConfig),
         {ok, _SupPid} ?= arizona_example_sup:start_link()


### PR DESCRIPTION
# Description

- Enable automatic reloading for development
- Watch src/ directory for .erl file changes with compile and reload
- Watch priv/static/assets for favicon and .js file changes
- Improves developer experience with hot reloading

---

- [ ] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/arizona-framework/arizona_example/blob/main/CONTRIBUTING.md)
