### PR TITLE
Update handle_event to use new action list return format

### DIFF
--- a/src/arizona_example_counter.erl
+++ b/src/arizona_example_counter.erl
@@ -30,12 +30,12 @@ render(Bindings) ->
     </div>
     """).
 
--spec handle_event(Event, Params, State) -> {noreply, State1} when
+-spec handle_event(Event, Params, State) -> Result when
     Event :: arizona_stateful:event_name(),
     Params :: arizona_stateful:event_params(),
     State :: arizona_stateful:state(),
-    State1 :: arizona_stateful:state().
+    Result :: arizona_stateful:handle_event_result().
 handle_event(~"incr", #{~"incr" := Incr}, State) ->
     Count = arizona_stateful:get_binding(count, State),
     State1 = arizona_stateful:put_binding(count, Count + Incr, State),
-    {noreply, State1}.
+    {[], State1}.

--- a/src/arizona_example_view.erl
+++ b/src/arizona_example_view.erl
@@ -47,11 +47,9 @@ render(Bindings) ->
     Event :: arizona_stateful:event_name(),
     Params :: arizona_stateful:event_params(),
     View :: arizona_view:view(),
-    Result :: {reply, Reply, View1} | {noreply, View1},
-    Reply :: arizona_stateful:event_reply(),
-    View1 :: arizona_view:view().
+    Result :: arizona_view:handle_event_result().
 handle_event(~"reload", FileType, View) ->
-    {reply, #{~"reload" => FileType}, View}.
+    {[{reply, #{~"reload" => FileType}}], View}.
 
 initialize_connected_session() ->
     arizona_pubsub:join(~"reload", self()).


### PR DESCRIPTION
# Description

- Change return from `{noreply, State}` to `{[], State}` in counter
- Change return from `{reply, Reply, View}` to `{[{reply, Reply}], View}` in view
- Update type specs to use `arizona_stateful:handle_event_result()` types
- Adapt to new Arizona action-based event handling system

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona_example/blob/main/CONTRIBUTING.md)
