### PR TITLE
Update route configuration to include middleware list

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -5,14 +5,14 @@
             transport_opts => [{port, 8080}],
             routes => [
                 % Static assets
-                {asset, ~"/favicon.ico", {priv_file, arizona_example, ~"static/favicon.ico"}},
-                {asset, ~"/robots.txt", {priv_file, arizona_example, ~"static/robots.txt"}},
-                {asset, ~"/assets/example", {priv_dir, arizona_example, ~"static/assets"}},
-                {asset, ~"/assets", {priv_dir, arizona, ~"static/assets"}},
+                {asset, ~"/favicon.ico", {priv_file, arizona_example, ~"static/favicon.ico"}, []},
+                {asset, ~"/robots.txt", {priv_file, arizona_example, ~"static/robots.txt"}, []},
+                {asset, ~"/assets/example", {priv_dir, arizona_example, ~"static/assets"}, []},
+                {asset, ~"/assets", {priv_dir, arizona, ~"static/assets"}, []},
                 % View routes
-                {view, ~"/", arizona_example_view, undefined},
+                {view, ~"/", arizona_example_view, undefined, []},
                 % WebSocket endpoint
-                {websocket, ~"/live"}
+                {websocket, ~"/live", #{}, []}
             ]
         }},
         {reloader, #{


### PR DESCRIPTION
# Description

Add empty middleware list [] to all route definitions to match new Arizona server route format:
- asset routes now have 4-tuple format with middleware list
- view routes now have 5-tuple format with middleware list
- websocket routes now have 4-tuple format with options and middleware list

---

- [ ] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/arizona-framework/arizona_example/blob/main/CONTRIBUTING.md)
