### PR TITLE
Update Arizona WebSocket connection API

### DIFF
--- a/priv/static/assets/js/main.js
+++ b/priv/static/assets/js/main.js
@@ -7,7 +7,7 @@ import Arizona from '/assets/js/arizona.min.js';
 globalThis.arizona = new Arizona();
 
 // Connect to the WebSocket server
-arizona.connect({ wsPath: '/live' });
+arizona.connect('/live');
 
 document.addEventListener('arizonaEvent', (event) => {
   const { type, data } = event.detail;


### PR DESCRIPTION
# Description

Change from arizona.connect({ wsPath: '/live' }) to arizona.connect('/live') to align with simplified Arizona client API.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona_example/blob/main/CONTRIBUTING.md)
