### PR TITLE
Update to latest Arizona breaking changes

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -4,15 +4,14 @@
             enabled => true,
             transport_opts => [{port, 8080}],
             routes => [
+                {asset, ~"/assets/arizona", {priv_dir, arizona, ~"static/assets"}, []},
+                {websocket, ~"/live", #{}, []},
                 % Static assets
                 {asset, ~"/favicon.ico", {priv_file, arizona_example, ~"static/favicon.ico"}, []},
                 {asset, ~"/robots.txt", {priv_file, arizona_example, ~"static/robots.txt"}, []},
-                {asset, ~"/assets/example", {priv_dir, arizona_example, ~"static/assets"}, []},
-                {asset, ~"/assets", {priv_dir, arizona, ~"static/assets"}, []},
+                {asset, ~"/assets", {priv_dir, arizona_example, ~"static/assets"}, []},
                 % View routes
-                {view, ~"/", arizona_example_view, undefined, []},
-                % WebSocket endpoint
-                {websocket, ~"/live", #{}, []}
+                {view, ~"/", arizona_example_view, undefined, []}
             ]
         }},
         {reloader, #{

--- a/priv/static/assets/js/main.js
+++ b/priv/static/assets/js/main.js
@@ -1,17 +1,10 @@
 /* global arizona */
 
 // Import the new Arizona client
-import Arizona from '/assets/js/arizona.min.js';
+import Arizona from '/assets/arizona/js/arizona.min.js';
 
 // Initialize the Arizona client
 globalThis.arizona = new Arizona();
 
 // Connect to the WebSocket server
 arizona.connect('/live');
-
-document.addEventListener('arizonaEvent', (event) => {
-  const { type, data } = event.detail;
-  if (type !== 'reply') return;
-  if (typeof data?.reload !== 'string') return;
-  window.location.reload();
-});

--- a/src/arizona_example_components.erl
+++ b/src/arizona_example_components.erl
@@ -5,14 +5,14 @@
 -ignore_xref([button/1]).
 
 -spec button(Bindings) -> Template when
-    Bindings :: arizona_binder:bindings(),
+    Bindings :: map(),
     Template :: arizona_template:template().
 button(Bindings) ->
-    arizona_template:from_html(~"""
-    <button
-        type="{arizona_template:get_binding(type, Bindings, ~"button")}"
-        onclick="{arizona_template:get_binding(onclick, Bindings)}"
-    >
-        {arizona_template:get_binding(text, Bindings)}
-    </button>
-    """).
+    arizona_template:from_erl(
+        {button,
+            [
+                {type, arizona_template:get_binding(type, Bindings, ~"button")},
+                {onclick, arizona_template:get_binding(onclick, Bindings)}
+            ],
+            arizona_template:get_binding(text, Bindings)}
+    ).

--- a/src/arizona_example_counter.erl
+++ b/src/arizona_example_counter.erl
@@ -7,32 +7,32 @@
 -export([handle_event/3]).
 
 -spec mount(Bindings) -> State when
-    Bindings :: arizona_binder:map(),
+    Bindings :: map(),
     State :: arizona_stateful:state().
 mount(Bindings) ->
     arizona_stateful:new(?MODULE, Bindings).
 
 -spec render(Bindings) -> Template when
-    Bindings :: arizona_binder:bindings(),
+    Bindings :: map(),
     Template :: arizona_template:template().
 render(Bindings) ->
-    arizona_template:from_html(~"""
-    <div id="{arizona_template:get_binding(id, Bindings)}">
-        <span>{arizona_template:get_binding(count, Bindings)}</span>
-        {arizona_template:render_stateless(arizona_example_components, button, #{
-            text => ~"Increment",
-            onclick => <<"arizona.sendEventTo("
-                "'", (arizona_template:get_binding(id, Bindings))/binary, "',"
-                "'incr', "
-                "\{incr: 1},"
-            ")">>
-         })}
-    </div>
-    """).
+    arizona_template:from_erl(
+        {'div', [{id, arizona_template:get_binding(id, Bindings)}], [
+            {span, [], arizona_template:get_binding(count, Bindings)},
+            arizona_template:render_stateless(arizona_example_components, button, #{
+                text => ~"Increment",
+                onclick => [
+                    ~"arizona.pushEventTo('",
+                    arizona_template:get_binding(id, Bindings),
+                    ~"', 'incr', {incr: 1})"
+                ]
+            })
+        ]}
+    ).
 
--spec handle_event(Event, Params, State) -> Result when
+-spec handle_event(Event, Payload, State) -> Result when
     Event :: arizona_stateful:event_name(),
-    Params :: arizona_stateful:event_params(),
+    Payload :: arizona_stateful:event_payload(),
     State :: arizona_stateful:state(),
     Result :: arizona_stateful:handle_event_result().
 handle_event(~"incr", #{~"incr" := Incr}, State) ->

--- a/src/arizona_example_layout.erl
+++ b/src/arizona_example_layout.erl
@@ -5,36 +5,36 @@
 -ignore_xref([render/1]).
 
 -spec render(Bindings) -> Template when
-    Bindings :: arizona_binder:bindings(),
+    Bindings :: map(),
     Template :: arizona_template:template().
 render(Bindings) ->
-    arizona_template:from_html(~""""
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>{arizona_template:get_binding(title, Bindings)}</title>
-        <style>
-        html \{
-            height: 100%;
-        }
-        body \{
-            height: 100%;
-            margin: 0;
-        }
-        main \{
-           display: flex;
-           flex-direction: column;
-           row-gap: 1rem;
-           padding: 1rem;
-        }
-        </style>
-        <script type="module" src="/assets/example/js/main.js"></script>
-    </head>
-    <body>
-        {arizona_template:render_slot(arizona_template:get_binding(inner_content, Bindings))}
-    </body>
-    </html>
-    """").
+    arizona_template:from_erl([
+        ~"<!DOCTYPE html>",
+        {html, [{lang, ~"en"}], [
+            {head, [], [
+                {meta, [{charset, ~"UTF-8"}]},
+                {meta, [{'http-equiv', ~"X-UA-Compatible"}, {content, ~"IE=edge"}]},
+                {meta, [{name, ~"viewport"}, {content, ~"width=device-width, initial-scale=1.0"}]},
+                {title, [], arizona_template:get_binding(title, Bindings)},
+                {style, [], ~"""
+                html {
+                    height: 100%;
+                }
+                body {
+                    height: 100%;
+                    margin: 0;
+                }
+                main {
+                   display: flex;
+                   flex-direction: column;
+                   row-gap: 1rem;
+                   padding: 1rem;
+                }
+                """},
+                {script, [{type, ~"module"}, {src, ~"/assets/js/main.js"}], []}
+            ]},
+            {body, [], [
+                arizona_template:render_slot(arizona_template:get_binding(inner_content, Bindings))
+            ]}
+        ]}
+    ]).


### PR DESCRIPTION
# Description

Major API updates to align with Arizona framework:

- Template API: Replace from_html with from_erl using Erlang tuple syntax
- Type system: Change arizona_binder types to plain map()
- Event API: Rename event_params to event_payload
- JavaScript client: Update asset path from /assets/js/ to /assets/arizona/js/
- JavaScript events: Change sendEventTo to pushEventTo
- Routes: Reorder Arizona assets first, websocket before views
- Remove custom reload event handling (now built-in)
- Enable reloader for development
- Simplify view mount by removing query param handling

These changes reflect Arizona's move to Erlang-native template syntax and streamlined event handling system.

---

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/arizona-framework/arizona_example/blob/main/CONTRIBUTING.md)
